### PR TITLE
additional variable to audit content location change

### DIFF
--- a/cat_3/RHEL-08-010375.yml
+++ b/cat_3/RHEL-08-010375.yml
@@ -20,7 +20,7 @@ command:
     - '!/.*kernel.dmesg_restrict( |)=( |)0/'
     meta:
       Cat: 3
-      CCCI: CCI-001090
+      CCI: CCI-001090
       Group_Title: SRG-OS-000138-GPOS-00069
       Rule_ID: SV-230269r792879_rule
       STIG_ID: RHEL-08-010375

--- a/docs/Security_remediation_and_auditing.md
+++ b/docs/Security_remediation_and_auditing.md
@@ -62,6 +62,7 @@ It can be run in two ways:
 
 - RHEL 7
 - RHEL 8
+- RHEL 9 (this is not yet GA as an OS but based on rh8)
 - Ubuntu 20.04
 - Windows 2016 Standalone, Member and Controller (in testing August 21)
 - Windows 2019 Standalone, Member and Controller (in testing August 21)
@@ -132,16 +133,24 @@ Minimal setup -- needs access to github
 
 ## Alternate source options
 
+```audit_run_script_environment```
+
+- Set correct env for the run_audit.sh script from https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
+
+```yaml
+audit_run_script_environment:
+  AUDIT_BIN: "{{ audit_bin }}"
+  AUDIT_FILE: 'goss.yml'
+  AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
+```
+
 ```audit_content```
 
-> default: git
-
-- Where the audit content is being retrieved from options include
-  - git:
+> default: git  # where the audit content is being pulled from if running from local
 
 ```audit_file_git```
 
-> default:  ```https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git```
+> default:  https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git
 
 ```audit_git_version```
 
@@ -159,26 +168,29 @@ We have allowed two options using the same variables
 
 - Settings:
 
-  ```audit_conf_copy```
+```audit_conf_copy```
 
-    > default: (change accordingly for your environment)
+  > default: (change accordingly for your environment)
 
-    e.g. Path on the control node to copy path/archive from
+e.g. Path on the control node to copy path/archive from
 
-  ```audit_conf_dir``` (change as required copy as dir or extract archive)
+```audit_conf_dir```
 
-    > Directory on the managed node where the audit conf files will run
-    > from.
-    >
-    > Used for the copy and the running of the audit
+(change as required copy as dir or extract archive)
+
+  > Directory on the managed node where the audit conf files will run
+  > from.
+  > Used for the copy and the running of the audit
 
 Alternate options
 
 ```get_url``` ( to be set according to your requirements)
 
+```yaml
 - {{ audit_file_url }} -- As description
+```
 
-```local or none```
+- local or none
 
   > This assumes content is already on the system and utilises the check
   > that are already there (see audit_conf_dir setting)
@@ -282,9 +294,9 @@ script variables
 example:
 
 ```sh
-AUDIT_BIN=/usr/local/bin/goss  # location of the goss executable
-AUDIT_FILE=goss.yml  # the default goss file used by the audit provided by the audit configuration
-AUDIT_CONTENT_LOCATION=/var/tmp  # Location of the audit configuration file as available to the OS
+AUDIT_BIN="${AUDIT_BIN:-/usr/local/bin/goss}"  # location of the goss executable
+AUDIT_FILE="${AUDIT_FILE:-goss.yml}"  # the default goss file used by the audit provided by the audit configuration
+AUDIT_CONTENT_LOCATION="${AUDIT_CONTENT_LOCATION:-/var/tmp}"  # Location of the audit configuration file as available to the OS
 ```
 
 script help
@@ -292,8 +304,9 @@ script help
 ```sh
 Script to run the goss audit
 
-Syntax: ./run_audit.sh [-g|-o|-v|-w|-h]
+Syntax: ./run_audit.sh [-f|-g|-o|-v|-w|-h]
 options:
+-f     optional - change the format output (default value = json)
 -g     optional - Add a group that the server should be grouped with (default value = ungrouped)
 -o     optional - file to output audit data
 -v     optional - relative path to thevars file to load (default e.g. /var/tmp/RHEL7-CIS/vars/CIS.yml)
@@ -308,12 +321,62 @@ Other options can be assigned in the script itself
 Similar to the Linux variables that can be set within the script
 
 ```sh
-$AUDIT_BIN = "C:\vagrant\goss.exe"
-$AUDIT_FILE = "goss.yml"
-$AUDIT_VARS = "vars\$BENCHMARK.yml"
-$AUDIT_CONTENT_LOCATION = "C:\vagrant"
-$AUDIT_CONTENT_VERSION = "Win2019-$BENCHMARK-Audit"
-$AUDIT_CONTENT_DIR = "$AUDIT_CONTENT_LOCATION\$AUDIT_CONTENT_VERSION"
+NAME
+    C:\remediation_audit_logs\Windows-2019-CIS-Audit\run_audit.ps1
+
+SYNOPSIS
+    Wrapper script to run an audit
+
+
+SYNTAX
+    C:\remediation_audit_logs\Windows-2016-CIS-Audit\run_audit.ps1 [[-auditbin] <String>] [[-auditdir] <String>]
+    [[-varsfile] <String>] [[-group] <String>] [[-outfile] <String>] [<CommonParameters>]
+
+
+DESCRIPTION
+    Wrapper script to run an audit on the system using goss.
+    This allows for bespoke variables to be set
+
+
+PARAMETERS
+    -auditbin <String>
+
+    -auditdir <String>
+        default: $DEFAULT_CONTENT_DIR
+        Ability to change the location of where the content can be found
+        This is where the audit content is stored
+        e.g. c:/windows_audit
+
+    -varsfile <String>
+        default: $DEFAULT_VARS_FILE
+        Ability to set a variable file defined with the settings to match your requirements
+
+    -group <String>
+        default: none
+        Ability to set a group that the system belongs to
+        Can be used when matching similar system in that same group
+
+    -outfile <String>
+        default: $AUDIT_CONTENT_DIR\audit_$host_os_hostname_$host_epoch.json
+        Ability to set an outfile to send the full audit output to
+        Requires path to be set.
+        e.g. c:/windows_audit_reports
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS C:\>./run_audit.ps1
+
+    ./run_audit.ps1 -auditbin c:\path_to\binary.name
+    ./run_audit.ps1 -auditdir c:\somepath_for _audit_content
+    ./run_audit.ps1 -varsfile myvars.yml
+    ./run_audit.ps1 -outfile path\to\audit\output.json
+    ./run_audit.ps1 -group webserver
 ```
 
 script itself

--- a/run_audit.sh
+++ b/run_audit.sh
@@ -7,6 +7,8 @@
 #             - Ability to run as script from remediation role increased consistency
 # 17 Dec 2021 - Added system_type variable - default Server will change to workstations with -w switch
 # 02 Mar 2022 - Updated benchmark variable naming
+# 06 Apr 2022 - Added format option in output inline with goss options e.g. json documentation this is for fault finding
+# 03 May 2022 - update for audit variables improvement added by @pavloos - https://github.com/ansible-lockdown/RHEL8-CIS-Audit/pull/29
 
 
 #!/bin/bash
@@ -16,9 +18,9 @@
 # lower case variables are discovered or built from other variables
 
 # Goss host Variables
-AUDIT_BIN=/usr/local/bin/goss  # location of the goss executable
-AUDIT_FILE=goss.yml  # the default goss file used by the audit provided by the audit configuration
-AUDIT_CONTENT_LOCATION=/var/tmp  # Location of the audit configuration file as available to the OS
+AUDIT_BIN="${AUDIT_BIN:-/usr/local/bin/goss}"  # location of the goss executable
+AUDIT_FILE="${AUDIT_FILE:-goss.yml}"  # the default goss file used by the audit provided by the audit configuration
+AUDIT_CONTENT_LOCATION="${AUDIT_CONTENT_LOCATION:-/var/tmp}"  # Location of the audit configuration file as available to the OS
 
 
 # Goss benchmark variables (these should not need changing unless new release)


### PR DESCRIPTION
Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>

Ability to use environment variables to enable the audit to run to a different location
Thanks to 
https://github.com/ansible-lockdown/RHEL8-CIS/pull/191 improvements added by @pavloos

added fix for
metadata in cat3 010375.yml


tested on rhel8-cis (all use same settings and vars)