### PR TITLE
STIG v1r11 release updated

### DIFF
--- a/vars/STIG.yml
+++ b/vars/STIG.yml
@@ -489,6 +489,7 @@ rhel8stig_auditd_disk_full_action: HALT
 # RHEL_08_030690 if using remote syslog server
 rhel8stig_remotelog_server: 1.1.1.1
 rhel8stig_remotelog_port: 1549
+rhel8stig_remotelog_protocol: '@@'
 
 # RHEL_08_040137
 python_bin: '/usr/bin/python'


### PR DESCRIPTION
Controls updated

- CAT2:
  - 010030 - ruleid
  - 010200 - ruleid
  - 010201 - ruleid
  - 010290 - ruleid and SSH MACS updated
  - 010291 - ruleid and SSH Ciphers updated
  - 010770 - ruleid
  - 020035 - new control idlesession timeout new var rhel_08_020035_idlesessiontimeout
  - 020041 - ruleid and tmux script update
  - 030690 - ruleid and protocol options added
  - 040159 - ruleid
  - 040160 - ruleid
  - 040342 - ruleid and SSH KEX algorithms updated

- CAT3
  - 010471 - ruleid

- audit variables updated, new version
- tidied up the end of the playbook ordering with reboot taking place(if set and enabled) prior to audit now.