### PR TITLE
Benchmark v1r11 rh8 into devel

### DIFF
--- a/Changelog.MD
+++ b/Changelog.MD
@@ -1,5 +1,25 @@
 # Changelog
 
+## STIG V1R11 26th July 2023
+Controls updated
+
+- CAT2:
+  - 010030 - ruleid
+  - 010200 - ruleid
+  - 010201 - ruleid
+  - 010290 - ruleid and SSH MACS updated
+  - 010291 - ruleid and SSH Ciphers updated
+  - 010770 - ruleid
+  - 020035 - new control idlesession timeout new var rhel_08_020035_idlesessiontimeout
+  - 020041 - ruleid and tmux script update
+  - 030690 - ruleid and protocol options added
+  - 040159 - ruleid
+  - 040160 - ruleid
+  - 040342 - ruleid and SSH KEX algorithms updated
+
+- CAT3
+  - 010471 - ruleid
+
 ## Stig V1R10 27th April 2023
 
 - Added new controls

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-based on STIG v1r10 27th April 2023
+based on STIG v1r11 26th July 2023
 
 Ability to audit a system using a lightweight binary to check the current state.
 

--- a/cat_2/RHEL-08-010000_010830/RHEL-08-010030.yml
+++ b/cat_2/RHEL-08-010000_010830/RHEL-08-010030.yml
@@ -7,7 +7,7 @@ package:
       Cat: 2
       CCI: CCI-001199
       Group_Title: SRG-OS-000185-GPOS-00079
-      Rule_ID: SV-230224r809268_rule
+      Rule_ID: SV-230224r917864_rule
       STIG_ID: RHEL-08-010030
       Vul_ID: V-230224
 command:

--- a/cat_2/RHEL-08-010000_010830/RHEL-08-010200.yml
+++ b/cat_2/RHEL-08-010000_010830/RHEL-08-010200.yml
@@ -14,7 +14,7 @@ command:
       Cat: 2
       CCI: CCI-001133
       Group_Title: SRG-OS-000163-GPOS-00072
-      Rule_ID: SV-230244r858697_rule
+      Rule_ID: SV-230244r917867_rule
       STIG_ID: RHEL-08-010200
       Vul_ID: V-230244
 {{ end }}

--- a/cat_2/RHEL-08-010000_010830/RHEL-08-010201.yml
+++ b/cat_2/RHEL-08-010000_010830/RHEL-08-010201.yml
@@ -14,7 +14,7 @@ command:
       Cat: 2
       CCI: CCI-001133
       Group_Title: SRG-OS-000163-GPOS-00072
-      Rule_ID: SV-244525r858699_rule
+      Rule_ID: SV-244525r917886_rule
       STIG_ID: RHEL-08-010201
       Vul_ID: V-244525
 {{ end }}

--- a/cat_2/RHEL-08-010000_010830/RHEL-08-010290.yml
+++ b/cat_2/RHEL-08-010000_010830/RHEL-08-010290.yml
@@ -10,7 +10,7 @@ command:
       Cat: 2
       CCI: CCI-001453
       Group_Title: SRG-OS-000250-GPOS-00093
-      Rule_ID: SV-230251r743937_rule
+      Rule_ID: SV-230251r917870_rule
       STIG_ID: RHEL-08-010290
       Vul_ID: V-230251
   crypto_policies_openssh_server_macs:
@@ -18,12 +18,12 @@ command:
     exec: grep -i crypto /etc/crypto-policies/back-ends/opensshserver.config
     exit-status: 0
     stdout:
-    - '/^CRYPTO_POLICY=.-oCiphers=aes256-ctr,aes192-ctr,aes128-ctr -oMACS=hmac-sha2-512,hmac-sha2-256./'
+    - '/^CRYPTO_POLICY=.*-oMACS=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com.*/'
     meta:
       Cat: 2
       CCI: CCI-001453
       Group_Title: SRG-OS-000250-GPOS-00093
-      Rule_ID: SV-230251r743937_rule
+      Rule_ID: SV-230251r917870_rule
       STIG_ID: RHEL-08-010290
       Vul_ID: V-230251
 {{ end }}

--- a/cat_2/RHEL-08-010000_010830/RHEL-08-010291.yml
+++ b/cat_2/RHEL-08-010000_010830/RHEL-08-010291.yml
@@ -10,20 +10,20 @@ command:
       Cat: 2
       CCI: CCI-001453
       Group_Title: SRG-OS-000250-GPOS-00093
-      Rule_ID: SV-230252r743940_rule
-      STIG_ID: RHEL-08-010290
+      Rule_ID: SV-230252r917873_rule
+      STIG_ID: RHEL-08-010291
       Vul_ID: V-230252
   crypto_policies_openssh_server_ciphers:
     title: RHEL-08-010291 | The RHEL 8 operating system must implement DoD-approved encryption to protect the confidentiality of SSH connections. | crypto-policies - ssh_server
     exec: grep -i crypto /etc/crypto-policies/back-ends/opensshserver.config
     exit-status: 0
     stdout:
-    - '/^CRYPTO_POLICY=.-oCiphers=aes256-ctr,aes192-ctr,aes128-ctr./'
+    - '/^CRYPTO_POLICY=.*-oCiphers=aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com.*/'
     meta:
       Cat: 2
       CCI: CCI-001453
       Group_Title: SRG-OS-000250-GPOS-00093
-      Rule_ID: SV-230252r743940_rule
+      Rule_ID: SV-230252r917873_rule
       STIG_ID: RHEL-08-010291
       Vul_ID: V-230252
 {{ end }}

--- a/cat_2/RHEL-08-010000_010830/RHEL-08-010770.yml
+++ b/cat_2/RHEL-08-010000_010830/RHEL-08-010770.yml
@@ -12,7 +12,7 @@ command:
       Cat: 2
       CCI: CCI-000366
       Group_Title: SRG-OS-000480-GPOS-00227
-      Rule_ID: SV-230325r627750_rule
+      Rule_ID: SV-230325r917879_rule
       STIG_ID: RHEL-08-010770
       Vul_ID: V-230325
   {{ end }}

--- a/cat_2/RHEL-08-020000_020353/RHEL-08-020035.yml
+++ b/cat_2/RHEL-08-020000_020353/RHEL-08-020035.yml
@@ -1,0 +1,16 @@
+{{ if .Vars.RHEL_08_020035 }}
+file:
+  /etc/systemd/logind.conf:
+    title: RHEL-08-020035 | RHEL 8 must terminate idle user sessions.
+    exists: true
+    contains:
+    - '/^StopIdleSessionSec=900/'
+    - '!/^StopIdleSessionSec=([1-9][0-9]|[1-8][0-9][0-9]|9[0-9][1-9]|[1-9]{3,})/'
+    meta:
+      Cat: 2
+      CCI: CCI-001133
+      Group_Title: SRG-OS-000163-GPOS-00072
+      Rule_ID: SV-257258r917891_rule
+      STIG_ID: RHEL-08-020035
+      Vul_ID: V-257258
+{{ end }}

--- a/cat_2/RHEL-08-020000_020353/RHEL-08-020041.yml
+++ b/cat_2/RHEL-08-020000_020353/RHEL-08-020041.yml
@@ -7,13 +7,13 @@ file:
     - '/^if \[ "\$PS1" \]; then/'
     - '/^parent=\$\(ps -o ppid= -p \$\$\)/'
     - '/^name=\$\(ps -o comm= -p \$parent\)/'
-    - '/^case "\$name" in \(sshd|login\) exec tmux ;; esac/'
+    - '/^case "\$name" in \(sshd|login\) tmux ;; esac/'
     - '/^fi/'
     meta:
       Cat: 2
       CCI: CCI-000056
       Group_Title: SRG-OS-000028-GPOS-00009
-      Rule_ID: SV-230349r880737_rule
+      Rule_ID: SV-230349r917920_rule
       STIG_ID: RHEL-08-020041
       Vul_ID: V-230349
 command:
@@ -27,7 +27,7 @@ command:
       Cat: 2
       CCI: CCI-000056
       Group_Title: SRG-OS-000028-GPOS-00009
-      Rule_ID: SV-230349r880737_rule
+      Rule_ID: SV-230349r917920_rule
       STIG_ID: RHEL-08-020041
       Vul_ID: V-230349
 {{ end }}

--- a/cat_2/RHEL-08-030000_030740/RHEL-08-030690.yml
+++ b/cat_2/RHEL-08-030000_030740/RHEL-08-030690.yml
@@ -13,7 +13,7 @@ command:
       Cat: 2
       CCI: CCI-001851
       Group_Title: SRG-OS-000342-GPOS-00133
-      Rule_ID: SV-230479r627750_rule
+      Rule_ID: SV-230479r917883_rule
       STIG_ID: RHEL-08-030690
       Vul_ID: V-230479
 {{ end }}

--- a/cat_2/RHEL-08-040000_040390/RHEL-08-040159.yml
+++ b/cat_2/RHEL-08-040000_040390/RHEL-08-040159.yml
@@ -7,7 +7,7 @@ package:
       Cat: 2
       CCI: CCI-002418
       Group_Title: SRG-OS-000423-GPOS-00187
-      Rule_ID: SV-244549r743896_rule
+      Rule_ID: SV-244549r916422_rule
       STIG_ID: RHEL-08-040159
       Vul_ID: V-244549
 {{ end }}

--- a/cat_2/RHEL-08-040000_040390/RHEL-08-040160.yml
+++ b/cat_2/RHEL-08-040000_040390/RHEL-08-040160.yml
@@ -8,7 +8,7 @@ service:
       Cat: 2
       CCI: CCI-002418
       Group_Title: SRG-OS-000423-GPOS-00187
-      Rule_ID: SV-230526r744032_rule
+      Rule_ID: SV-230526r916422_rule
       STIG_ID: RHEL-08-040160
       Vul_ID: V-230526
 {{ end }}

--- a/cat_2/RHEL-08-040000_040390/RHEL-08-040342.yml
+++ b/cat_2/RHEL-08-040000_040390/RHEL-08-040342.yml
@@ -9,7 +9,7 @@ file:
       Cat: 2
       CCI: CCI-001453
       Group_Title: SRG-OS-000250-GPOS-00093
-      Rule_ID: SV-255924r880733_rule
+      Rule_ID: SV-255924r917888_rule
       STIG_ID: RHEL-08-040342
       Vul_ID: V-255924
 {{ end }}

--- a/cat_3/RHEL-08-010471.yml
+++ b/cat_3/RHEL-08-010471.yml
@@ -8,7 +8,7 @@ service:
       Cat: 3
       CCI: CCI-000366
       Group_Title: SRG-OS-000480-GPOS-00227
-      Rule_ID: SV-230285r627750_rule
+      Rule_ID: SV-230285r917876_rule
       STIG_ID: RHEL-08-010471
       Vul_ID: V-230285
 {{ end }}

--- a/run_audit.sh
+++ b/run_audit.sh
@@ -26,7 +26,7 @@ AUDIT_CONTENT_LOCATION="${AUDIT_CONTENT_LOCATION:-/opt}"  # Location of the audi
 
 # Goss benchmark variables (these should not need changing unless new release)
 BENCHMARK=STIG  # Benchmark Name aligns to the audit
-BENCHMARK_VER=V1R10
+BENCHMARK_VER=V1R11
 BENCHMARK_OS=RHEL8
 
 # help output

--- a/vars/STIG.yml
+++ b/vars/STIG.yml
@@ -489,6 +489,7 @@ rhel8stig_auditd_disk_full_action: HALT
 # RHEL_08_030690 if using remote syslog server
 rhel8stig_remotelog_server: 1.1.1.1
 rhel8stig_remotelog_port: 1549
+rhel8stig_remotelog_protocol: '@@'
 
 # RHEL_08_040137
 python_bin: '/usr/bin/python'

--- a/vars/STIG.yml
+++ b/vars/STIG.yml
@@ -1,5 +1,5 @@
 ## metadata for Audit benchmark
-benchmark_version: '1.10'
+benchmark_version: '1.11'
 
 # set to redhat/rocky/alma/oracle
 rhel8stig_os_distribution: redhat
@@ -226,6 +226,7 @@ RHEL_08_020028: true
 RHEL_08_020030: true
 RHEL_08_020031: true
 RHEL_08_020032: true
+RHEL_08_020035: true
 RHEL_08_020039: true
 RHEL_08_020040: true
 RHEL_08_020041: true


### PR DESCRIPTION
**Overall Review of Changes:**
- CAT2:
  - 010030 - ruleid
  - 010200 - ruleid
  - 010201 - ruleid
  - 010290 - ruleid and SSH MACS updated
  - 010291 - ruleid and SSH Ciphers updated
  - 010770 - ruleid
  - 020035 - new control idlesession timeout new var rhel_08_020035_idlesessiontimeout
  - 020041 - ruleid and tmux script update
  - 030690 - ruleid and protocol options added
  - 040159 - ruleid
  - 040160 - ruleid
  - 040342 - ruleid and SSH KEX algorithms updated

- CAT3
  - 010471 - ruleid

**How has this been tested?:**
Manually
