### PR TITLE
revert rhel8stig_boot_superuser default to bootloader_admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - RHEL-08-010040 goss banner-content check: path `/etc/motd` -> `/etc/issue` to match the file the rem writes (motd is post-login, issue is pre-login banner per the XCCDF SSH-banner intent)
 - RHEL-08-010150 Rule_ID revision bump `SV-230235r1017054_rule` -> `SV-230235r1137691_rule` (missed by bulk sweep and prior verification pass)
 - vars/STIG.yml: added 7 missing `RHEL_08_*` toggle definitions (010015, 010270, 010275, 010280, 010472, 020360, 030655) - their goss test files gate on `{{ if .Vars.RHEL_08_<id> }}` against previously-undefined vars; tests would silently skip under strict mode
+- vars/STIG.yml: reverted `rhel8stig_boot_superuser` default `root` -> `bootloader_admin` to match the rem-side revert (rem asserts the boot superuser must NOT be an existing system user; `root` exists on every host and hard-fails the rem on real systems). Defense-in-depth: GRUB superuser should be distinct from login accounts.
 
 ## STIG V2R7 May 2026
 

--- a/vars/STIG.yml
+++ b/vars/STIG.yml
@@ -442,7 +442,7 @@ RHEL_08_040310: true
 # Variables
 
 rhel8stig_password_hash: grub.pbkdf2.sha512.changeme
-rhel8stig_boot_superuser: root
+rhel8stig_boot_superuser: bootloader_admin
 
 # RHEL_08_101120 & Auditd controls
 MIN_UID: 1000


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
revert rhel8stig_boot_superuser default to bootloader_admin

**How has this been tested?:**
Molecule
